### PR TITLE
Update nightly rustc to 2018-07-24

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     ############################################################
     lxc-attach -n cratesfyi-container -- apt-get update
     lxc-attach -n cratesfyi-container -- apt-get install -y --no-install-recommends curl ca-certificates binutils gcc libc6-dev libmagic1
-    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-03'
+    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-07-24'
 
     ############################################################
     # Creating rustc links for cratesfyi user                  #


### PR DESCRIPTION
The previous nightly 2018-06-03 suffers from rust-lang/rust#50561, which caused several packages failed to build (see https://github.com/onur/docs.rs/issues/23#issuecomment-397496013). This bug has been fixed on Jun 12th by rust-lang/rust#50617, so we just need to update the nightly beyond this date.