### PR TITLE
Fix Github links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 authors = ["Onur Aslan <onuraslan@gmail.com>"]
 readme = "README.md"
 license = "MIT"
-repository = "https://github.com/onur/cratesfyi"
+repository = "https://github.com/rust-lang-nursery/docs.rs"
 build = "build.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docs.rs
 
-[![Build Status](https://secure.travis-ci.org/onur/docs.rs.svg?branch=master)](https://travis-ci.org/onur/docs.rs)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/onur/docs.rs/master/LICENSE)
+[![Build Status](https://secure.travis-ci.org/rust-lang-nursery/docs.rs.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/docs.rs)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang-nursery/docs.rs/master/LICENSE)
 
 Docs.rs (formerly cratesfyi) is an open source project to host documentation
 of crates for the Rust Programming Language.
@@ -59,7 +59,7 @@ to able to download ~800MB data on the first run.
 
 
 ```sh
-git clone https://github.com/onur/docs.rs.git docs.rs
+git clone https://github.com/rust-lang-nursery/docs.rs.git docs.rs
 cd docs.rs
 vagrant up  # This may take a little while on the first run
 ```
@@ -151,7 +151,7 @@ cargo run -- doc <CRATE_NAME>
 
 #### Contributors
 
-* [Onur Aslan](https://github.com/onur)
+* [rust-lang-nursery Aslan](https://github.com/rust-lang-nursery)
 * [Jon Gjengset](https://github.com/jonhoo)
 * [Sebastian Thiel](https://github.com/Byron)
 * [Guillaume Gomez](https://github.com/GuillaumeGomez)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ cargo run -- doc <CRATE_NAME>
 
 #### Contributors
 
-* [rust-lang-nursery Aslan](https://github.com/rust-lang-nursery)
+* [Onur Aslan](https://github.com/rust-lang-nursery)
 * [Jon Gjengset](https://github.com/jonhoo)
 * [Sebastian Thiel](https://github.com/Byron)
 * [Guillaume Gomez](https://github.com/GuillaumeGomez)

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "Simple badge generator"
 authors = ["Onur Aslan <onur@onur.im>"]
 license-file = "LICENSE"
-repository = "https://github.com/onur/docs.rs"
+repository = "https://github.com/rust-lang-nursery/docs.rs"
 documentation = "https://docs.rs/badge"
 
 [lib]

--- a/src/web/badge/LICENSE
+++ b/src/web/badge/LICENSE
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: badge
-Source: https://github.com/onur/docs.rs
+Source: https://github.com/rust-lang-nursery/docs.rs
 
 Files: *
 Copyright: Copyright (c) 2016  Onur Aslan  <onur@onur.im>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -14,7 +14,7 @@
 
   <p>
   The source code of Docs.rs is available on
-    <a href="https://github.com/onur/docs.rs" target="_blank">GitHub</a>. If
+    <a href="https://github.com/rust-lang-nursery/docs.rs" target="_blank">GitHub</a>. If
   you ever encounter an issue, don't hesitate to report it! (And
   thanks in advance!)
   </p>


### PR DESCRIPTION
I updated most of the links to point to the new repository. This should also fix the CI badge.