### PR TITLE
Remove pc-windows-gnu targets

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -15,13 +15,11 @@ use error::Result;
 
 
 /// List of targets supported by docs.rs
-const TARGETS: [&'static str; 8] = [
+const TARGETS: [&'static str; 6] = [
     "i686-apple-darwin",
-    "i686-pc-windows-gnu",
     "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu",
     "x86_64-apple-darwin",
-    "x86_64-pc-windows-gnu",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu"
 ];


### PR DESCRIPTION
When I switched custom Rust builds, I never provided a build for pc-windows-gnu targets and nobody asked for them. I think it's safe to remove this targets from docs.rs to save up some space.