### PR TITLE
Use default-target to build package

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -215,7 +215,7 @@ impl DocBuilder {
 
         // only add target name to destination directory when we are copying a non-default target.
         // this is allowing us to host documents in the root of the crate documentation directory.
-        // for example win-api will be available in docs.rs/win-api/$version/win-api/ for it's
+        // for example winapi will be available in docs.rs/winapi/$version/winapi/ for it's
         // default target: x86_64-pc-windows-msvc. But since it will be built under
         // cratesfyi/x86_64-pc-windows-msvc we still need target in this function.
         if !is_default_target {

--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -203,11 +203,16 @@ impl DocBuilder {
                           target: Option<&str>,
                           is_default_target: bool)
                           -> Result<()> {
-        let crate_doc_path = PathBuf::from(&self.options.chroot_path)
+        let mut crate_doc_path = PathBuf::from(&self.options.chroot_path)
             .join("home")
             .join(&self.options.chroot_user)
-            .join("cratesfyi")
-            .join(target.unwrap_or(""));
+            .join("cratesfyi");
+
+        // docs are available in cratesfyi/$TARGET when target is being used
+        if let Some(target) = target {
+            crate_doc_path.push(target);
+        }
+
         let mut destination = PathBuf::from(&self.options.destination)
             .join(format!("{}/{}",
                           package.manifest().name(),
@@ -219,7 +224,9 @@ impl DocBuilder {
         // default target: x86_64-pc-windows-msvc. But since it will be built under
         // cratesfyi/x86_64-pc-windows-msvc we still need target in this function.
         if !is_default_target {
-            destination.push(target.unwrap_or(""));
+            if let Some(target) = target {
+                destination.push(target);
+            }
         }
 
         copy_doc_dir(crate_doc_path,

--- a/src/utils/copy.rs
+++ b/src/utils/copy.rs
@@ -14,8 +14,7 @@ pub fn copy_dir<P: AsRef<Path>>(source: P, destination: P) -> Result<()> {
     copy_files_and_handle_html(source.as_ref().to_path_buf(),
                                destination.as_ref().to_path_buf(),
                                false,
-                               "",
-                               false)
+                               "")
 }
 
 
@@ -27,23 +26,20 @@ pub fn copy_dir<P: AsRef<Path>>(source: P, destination: P) -> Result<()> {
 /// to rename common files (css files, jquery.js, playpen.js, main.js etc.) in a standard rustdoc.
 pub fn copy_doc_dir<P: AsRef<Path>>(target: P,
                                     destination: P,
-                                    rustc_version: &str,
-                                    target_platform: bool)
+                                    rustc_version: &str)
                                     -> Result<()> {
     let source = PathBuf::from(target.as_ref()).join("doc");
     copy_files_and_handle_html(source,
                                destination.as_ref().to_path_buf(),
                                true,
-                               rustc_version,
-                               target_platform)
+                               rustc_version)
 }
 
 
 fn copy_files_and_handle_html(source: PathBuf,
                               destination: PathBuf,
                               handle_html: bool,
-                              rustc_version: &str,
-                              target: bool)
+                              rustc_version: &str)
                               -> Result<()> {
 
     // FIXME: handle_html is useless since we started using --resource-suffix
@@ -72,8 +68,7 @@ fn copy_files_and_handle_html(source: PathBuf,
             try!(copy_files_and_handle_html(file.path(),
                                             destination_full_path,
                                             handle_html,
-                                            &rustc_version,
-                                            target));
+                                            &rustc_version))
         } else if handle_html && dup_regex.is_match(&file.file_name().into_string().unwrap()[..]) {
             continue;
         } else {
@@ -118,7 +113,7 @@ mod test {
         let pkg_dir = format!("rand-{}", pkg.manifest().version());
         let target = Path::new(&pkg_dir);
         let destination = tempdir::TempDir::new("cratesfyi").unwrap();
-        let res = copy_doc_dir(target, destination.path(), "UNKNOWN", false);
+        let res = copy_doc_dir(target, destination.path(), "UNKNOWN");
 
         // remove build and temp dir
         fs::remove_dir_all(target).unwrap();


### PR DESCRIPTION
This is my solution for default-target. It is using `default-target` metadata option to build package in first place and placing default build to root of the crate documentation directory.

For example winapi will always be build with `x86_64-pc-windows-msvc` target first and documentation crated with this target will be available in `docs.rs/winapi/$version/winapi/`.