### PR TITLE
fix issue link in "crate failed to build" message

### DIFF
--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -56,7 +56,7 @@
       <div class="warning">{{name}}-{{version}} is not a library.</div>
       {{else}}
       {{#unless build_status}}
-      <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and if you believe this is docs.rs' fault, report into <a href="https://github.com/onur/docs.rs/issues/23">this issue report</a>.</div>
+      <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and if you believe this is docs.rs' fault, report into <a href="https://github.com/rust-lang-nursery/docs.rs/issues/23">this issue report</a>.</div>
       {{else}}
       {{#unless rustdoc_status}}
       <div class="warning">{{name}}-{{version}} doesn't have any documentation.</div>


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/docs.rs/issues/261

Missed a spot in the migration to the nursery.